### PR TITLE
event-page-layout config

### DIFF
--- a/frontend/src/app/components/EventCard.tsx
+++ b/frontend/src/app/components/EventCard.tsx
@@ -18,9 +18,10 @@ export function EventCard({ event }: EventCardProps) {
     ? (uploadedImage ?? CATEGORY_IMAGES[event.category] ?? DEFAULT_CATEGORY_IMAGE)
     : null;
 
-  const organizerLabel = event.origin_type === 'user'
-    ? (event.user_name ?? `user #${event.user_id ?? 'unknown'}`)
-    : (event.organizer_name ?? event.venue_name ?? event.user_name ?? 'Event Organizer');
+  const organizerLabel = event.organizer_name
+    ?? event.user_name
+    ?? event.venue_name
+    ?? `user #${event.user_id ?? 'unknown'}`;
 
   return (
     <Link href={`/event/${event.id}`}>

--- a/frontend/src/app/lib/contracts.ts
+++ b/frontend/src/app/lib/contracts.ts
@@ -86,6 +86,7 @@ export interface EventCreateBody {
   neighborhood?: string;
   price_info?: string;
   event_image_url?: string;
+  organizer_name?: string;
 }
 
 export interface EventUpdateBody {

--- a/frontend/src/app/pages/CreateEvent.tsx
+++ b/frontend/src/app/pages/CreateEvent.tsx
@@ -30,6 +30,7 @@ export function CreateEvent() {
   ]);
   const [formData, setFormData] = useState({
     title: '',
+    organizerName: '',
     description: '',
     category: '',
     neighborhood: '',
@@ -89,6 +90,7 @@ export function CreateEvent() {
       await createEvent({
         user_id: user.id,
         title: formData.title,
+        organizer_name: formData.organizerName.trim() || undefined,
         category: formData.category,
         content: formData.description,
         neighborhood: formData.neighborhood || undefined,
@@ -209,6 +211,20 @@ export function CreateEvent() {
                   onChange={(e) => handleChange('title', e.target.value)}
                   required
                 />
+              </div>
+
+              {/* Organizer Label */}
+              <div className="space-y-2">
+                <Label htmlFor="organizerName">Organizer Label</Label>
+                <Input
+                  id="organizerName"
+                  placeholder="e.g., UC San Diego IEEE, North Park Community Council"
+                  value={formData.organizerName}
+                  onChange={(e) => handleChange('organizerName', e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Optional. Use this when you are posting on behalf of another organizer.
+                </p>
               </div>
 
               {/* Description */}

--- a/frontend/src/app/pages/Feed.tsx
+++ b/frontend/src/app/pages/Feed.tsx
@@ -14,6 +14,8 @@ import { Search, TrendingUp, LogOut, Filter, Plus } from 'lucide-react';
 import { toast } from 'sonner';
 import logoImage from '../../imports/CityPulse_Logo.png';
 
+const EVENTS_PER_PAGE = 9;
+
 export function Feed() {
   const router = useRouter();
   const [user, setUser] = useState<UserRead | null>(null);
@@ -28,6 +30,7 @@ export function Feed() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
 
   function startsAfterIsoFromDateInput(value: string): string | undefined {
     if (!value.trim()) {
@@ -123,8 +126,27 @@ export function Feed() {
     const matchesCity = selectedCity === 'San Diego, CA' || event.city === selectedCity;
     return matchesSearch && matchesCity;
   });
+  const totalPages = Math.max(1, Math.ceil(filteredEvents.length / EVENTS_PER_PAGE));
+  const pageStartIndex = (currentPage - 1) * EVENTS_PER_PAGE;
+  const paginatedEvents = filteredEvents.slice(pageStartIndex, pageStartIndex + EVENTS_PER_PAGE);
+  const startPage = Math.max(1, currentPage - 2);
+  const endPage = Math.min(totalPages, startPage + 4);
+  const visiblePageNumbers: number[] = [];
+  for (let pageNumber = Math.max(1, endPage - 4); pageNumber <= endPage; pageNumber += 1) {
+    visiblePageNumbers.push(pageNumber);
+  }
 
   const trendingEvents = filteredEvents.filter((event) => event.trending);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, selectedCategory, selectedNeighborhood, startDate]);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
 
   if (loading) {
     return (
@@ -233,6 +255,7 @@ export function Feed() {
                     setSelectedCategory('All Categories');
                     setSelectedNeighborhood('All Neighborhoods');
                     setStartDate('');
+                    setCurrentPage(1);
                     setRefreshToken((value) => value + 1);
                   }}
                 >
@@ -337,17 +360,50 @@ export function Feed() {
                 onClick={() => {
                   setSearchQuery('');
                   setSelectedCategory('All Categories');
+                  setCurrentPage(1);
                 }}
               >
                 Clear All Filters
               </Button>
             </div>
           ) : (
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-              {filteredEvents.map((event) => (
-                <EventCard key={event.id} event={event} />
-              ))}
-            </div>
+            <>
+              <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {paginatedEvents.map((event) => (
+                  <EventCard key={event.id} event={event} />
+                ))}
+              </div>
+              {filteredEvents.length > EVENTS_PER_PAGE && (
+                <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={currentPage === 1}
+                    onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+                  >
+                    Previous
+                  </Button>
+                  {visiblePageNumbers.map((pageNumber) => (
+                    <Button
+                      key={pageNumber}
+                      variant={pageNumber === currentPage ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => setCurrentPage(pageNumber)}
+                    >
+                      {pageNumber}
+                    </Button>
+                  ))}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={currentPage === totalPages}
+                    onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/src/app/routes/events.py
+++ b/src/app/routes/events.py
@@ -1,6 +1,7 @@
 """Event API: list events (default region san diego), create, update, delete."""
 
 from datetime import datetime
+import json
 from pathlib import Path as FilePath
 from uuid import uuid4
 
@@ -9,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user_required
 from app.database import get_db
-from app.event_metadata import clean_event_description, extract_organizer_name
+from app.event_metadata import clean_event_description, clean_organizer_name, extract_organizer_name
 from app.event_categories import (
     ALL_CATEGORIES_OPTION,
     ALLOWED_EVENT_CATEGORIES,
@@ -122,9 +123,8 @@ async def get_event(
     if not event:
         raise not_found("Event not found")
     organizer_name = (
-        event.user.name
-        if event.user is not None
-        else extract_organizer_name(event.tags_json)
+        extract_organizer_name(event.tags_json)
+        or (event.user.name if event.user is not None else None)
         or event.venue_name
         or (event.source.name if event.source else None)
     )
@@ -187,6 +187,7 @@ async def create_event(
     # for a persisted user row (and for `events.user_id` to reference it).
     if user.id is None:
         raise RuntimeError("User id missing from database record")
+    normalized_organizer_name = clean_organizer_name(payload.organizer_name)
     event = await create_event_row(
         db,
         region_id=user.region_id,
@@ -202,6 +203,11 @@ async def create_event(
         venue_address=payload.venue_address,
         neighborhood=payload.neighborhood,
         price_info=payload.price_info,
+        tags_json=(
+            json.dumps({"organizer_name": normalized_organizer_name})
+            if normalized_organizer_name is not None
+            else None
+        ),
     )
     return event
 

--- a/src/app/routes/interactions.py
+++ b/src/app/routes/interactions.py
@@ -119,9 +119,8 @@ async def list_events_with_interactions(
             source = await get_source_by_id(db, ev.source_id)
             source_name = source.name if source is not None else None
         organizer_name = (
-            ev.user.name
-            if ev.user is not None
-            else extract_organizer_name(ev.tags_json)
+            extract_organizer_name(ev.tags_json)
+            or (ev.user.name if ev.user is not None else None)
             or ev.venue_name
             or source_name
         )

--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -126,6 +126,7 @@ class EventCreate(BaseModel):
     neighborhood: str | None = Field(None, max_length=100)
     price_info: str | None = Field(None, max_length=255)
     event_image_url: str | None = Field(None, max_length=2048)
+    organizer_name: str | None = Field(None, min_length=1, max_length=255)
 
 
 class EventUpdate(BaseModel):

--- a/src/test/test_crud_endpoints.py
+++ b/src/test/test_crud_endpoints.py
@@ -138,6 +138,7 @@ def test_create_event_without_trailing_slash_succeeds(monkeypatch):
         venue_address,
         neighborhood,
         price_info,
+        tags_json=None,
     ):
         return Event(
             id=11,
@@ -171,6 +172,65 @@ def test_create_event_without_trailing_slash_succeeds(monkeypatch):
     app.dependency_overrides.clear()
     assert response.status_code == 201
     assert response.json()["id"] == 11
+
+
+def test_create_event_accepts_custom_organizer_label(monkeypatch):
+    captured_tags_json = None
+
+    async def _fake_create_event(
+        _db,
+        *,
+        region_id,
+        user_id,
+        title,
+        category,
+        content,
+        event_image_url,
+        event_start_at,
+        event_end_at,
+        timezone,
+        venue_name,
+        venue_address,
+        neighborhood,
+        price_info,
+        tags_json=None,
+    ):
+        nonlocal captured_tags_json
+        captured_tags_json = tags_json
+        return Event(
+            id=12,
+            region_id=region_id,
+            user_id=user_id,
+            title=title,
+            category=category,
+            content=content,
+            event_image_url=event_image_url,
+            created_at=datetime.now(UTC),
+            event_start_at=event_start_at,
+            event_end_at=event_end_at,
+            timezone=timezone,
+            venue_name=venue_name,
+            venue_address=venue_address,
+            neighborhood=neighborhood,
+            price_info=price_info,
+            tags_json=tags_json,
+        )
+
+    monkeypatch.setattr(events_router_module, "create_event_row", _fake_create_event)
+    client = _build_client(monkeypatch)
+    response = client.post(
+        "/api/events",
+        json={
+            "user_id": 1,
+            "title": "Community Cleanup",
+            "category": "Community",
+            "content": "body",
+            "organizer_name": "North Park Community Council",
+        },
+    )
+    app.dependency_overrides.clear()
+    assert response.status_code == 201
+    assert captured_tags_json == '{"organizer_name": "North Park Community Council"}'
 
 
 def test_update_event_not_found(monkeypatch):


### PR DESCRIPTION
organized page indexing to limit the number of events seen from user on one page to a max of 9 and allow the rest on seperate pages, for a more condensed organized look